### PR TITLE
Bugfixes for Census Geocoder and TIGERweb

### DIFF
--- a/cli/collection/address_geocoding.py
+++ b/cli/collection/address_geocoding.py
@@ -110,9 +110,14 @@ def census_geocode_records(df_chunk: pd.DataFrame) -> pd.DataFrame:
     geocoded_df = pd.read_csv(
         io.StringIO(r.text), names=GEOCODE_RESPONSE_HEADER, low_memory=False
     )
-    geocoded_df[["long", "lat"]] = (
-        geocoded_df["coordinates"].astype("str").str.split(",", expand=True)
-    )
+    # Split out the lat/long coordinates into different fields, BUT...
+    # First check whether ALL coordinates are empty (i.e., EVERY record in the chunk returned "No Match")
+    if geocoded_df['coordinates'].isna().all():
+        geocoded_df[["long", "lat"]] = [(np.nan, np.nan)] * len(geocoded_df)
+    else:
+        geocoded_df[["long", "lat"]] = (
+            geocoded_df["coordinates"].astype("str").str.split(",", expand=True)
+        )
 
     return geocoded_df
 

--- a/cli/collection/tigerweb_api.py
+++ b/cli/collection/tigerweb_api.py
@@ -16,12 +16,12 @@ def jprint(obj):
 # 2. Retrieving all census tracts for the given county
 def create_tigerweb_query(state_code: str, county_code: str) -> str:
     # Create an API call with the input state and county code
-    base_uri = "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2019/MapServer/8/query?where=STATE+%3D+"
-    connector = "+AND+COUNTY+%3D+"
+    base_uri = "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_ACS2019/MapServer/8/query?where="
+    connector = f"STATE%3D%27{state_code}%27+AND+COUNTY%3D%27{county_code}%27"
     end_uri = "&text=&objectIds=&time=&geometry=&geometryType=esriGeometryPolygon&inSR=&spatialRel=esriSpatialRelIntersects&distance=&units=esriSRUnit_Foot&relationParam=&outFields=&returnGeometry=true&returnTrueCurves=false&maxAllowableOffset=&geometryPrecision=&outSR=&havingClause=&returnIdsOnly=false&returnCountOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&gdbVersion=&historicMoment=&returnDistinctValues=false&resultOffset=&resultRecordCount=&returnExtentOnly=false&datumTransformation=&parameterValues=&rangeValues=&quantizationParameters=&featureEncoding=esriDefault&f=geojson"
 
     # Stich everything together
-    api_call = str(base_uri + state_code + connector + county_code + end_uri)
+    api_call = str(base_uri + connector + end_uri)
     return api_call
 
 


### PR DESCRIPTION
This PR makes the following changes:
- Handle the edge case where ALL records in the geocoding chunk return "No Match" from the Census Geocoder API
- Fix TIGERweb API call by enclosing `state_code` and `county_code` in quotes (returns error otherwise)