### PR TITLE
Acs mismatched year fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ geolocation data.
     3. The `full_datasets` directory contains all eviction/foreclosure geocoded records
     4. The `mapping_data` directory contains a geopackage (.gpkg) file that can be examined using QGIS
 
+# Setup
+
+1. Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) by selecting the installer that fits your OS version. Once it is installed you may have to restart your terminal (closing your terminal and opening again)
+2. `conda env create -f environment.yml` 
+4. `conda activate housing_loss_env` 
+
+
 ## Structure
 
 * `cli/` - code to run the DataKind New America Housing Loss Analysis Tool

--- a/README.md
+++ b/README.md
@@ -2,40 +2,51 @@
 
 A Command Line Interface (CLI) that allows users to ingest eviction, 
 foreclosure, and tax lien data and outputs statistical summaries and 
-geolocation data. 
+geolocation data.
 
-## Python CLI Usage Instructions
-1. Ensure your data format is configured based on the required specification 
-   1. This [Google Sheet](https://docs.google.com/spreadsheets/d/1WKxpcxZI_MMJJ5lqcwauhsuw3NBxwcG5/edit?usp=sharing&ouid=104702318722434350576&rtpof=true&sd=true) presents the data requirements
-   2. This [Example Directory](https://github.com/datakind/new-america-housing-loss-public/tree/main/cli/collection/tests/resources) shows a populated version of the format with random addresses
-2. Download Python 3.8.10 here: https://www.python.org/downloads/release/python-3810/ and follow the instructions to install Python
-3. Navigate to the New America Housing Loss Tool here: https://github.com/datakind/new-america-housing-loss-public.git
-4. Click `Code` and `Download Zip` to download the code
-5. Unzip the zip file in the directory of your choice
-6. Open a terminal or a command prompt and navigate to where the code was downloaded (note: this directory will end with `new-america-housing-loss-public-main`)
-7. Change directory to the `cli` using the command `cd cli` 
-8. If you are running Windows, you will need to run the following commands to install dependencies:
-   1. `py -m pip install whl/GDAL-3.3.3-cp38-cp38-win_amd64.whl`
-   2. `py -m pip install whl/Fiona-1.8.20-cp38-cp38-win_amd64.whl`
-9. Run the following commands to install dependencies:
-   1. For Mac/Linux, run `python -m pip install -r requirements.txt`
-   2. For Windows, run `py -m pip install -r requirements.txt`
-10. Run the tool against your data:
-    1. For Mac/Linux, run `python load_data.py /path/to/input_data/`
-    2. For Windows, run `py load_data.py C:\path\to\input_data\`
-11. The output will be available one level up from your data directory in a folder called `output_data`
-    1. The `analysis_plots` directory contains time series and correlation analysis of your content
-    2. The `data_summaries` directory contains a summary of evictions/foreclosures by geocode (enriched with American Community Survey (ACS) data)
-    3. The `full_datasets` directory contains all eviction/foreclosure geocoded records
-    4. The `mapping_data` directory contains a geopackage (.gpkg) file that can be examined using QGIS
+# Setup 
 
-# Setup
+Get the FEAT code ...
 
-1. Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) by selecting the installer that fits your OS version. Once it is installed you may have to restart your terminal (closing your terminal and opening again)
-2. `conda env create -f environment.yml` 
-4. `conda activate housing_loss_env` 
+1. Navigate to the New America Housing Loss Tool here: https://github.com/datakind/new-america-housing-loss-public.git
+2. Click `Code` and `Download Zip` to download the code
+3. Unzip the zip file in the directory of your choice
 
+Then setup the FEAT environment
 
-## Structure
+1Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) by selecting the installer that fits your OS version. Once it is installed you may have to restart your terminal (closing your terminal and opening again)
+2Build your environment:
+   - On Mac/Linux: 
+     - Open a terminal and change directory to be where you unzipped the FEAT code `new-america-housing-loss-public`
+     - `conda env create -f environment.yml` 
+   - On Windows: 
+     - In the search box bottom right, search for 'Anaconda prompt' and start it
+     - Change directory to be where you unzipped the FEAT code `new-america-housing-loss-public`
+       - `conda env create -f environment_win.yml`
 
-* `cli/` - code to run the DataKind New America Housing Loss Analysis Tool
+# Running FEAT
+
+First, create your input data ...
+
+1. Download [this spreadsheet](https://docs.google.com/spreadsheets/d/1WKxpcxZI_MMJJ5lqcwauhsuw3NBxwcG5/edit?usp=sharing&ouid=106808949113099347741&rtpof=true&sd=true)
+2. In the sheet populate tabs `Evictions`, `Mortgage Foreclosures` and `Tax Lien Foreclosures` with your data. Note, some tabs can be empty if you don't have data
+3. Save each tab as a csv file into the FEAT folders as follows:
+    - `evictions.csv` should be saved to `new-america-housing-loss-public/cli/work/evictions`
+    - `mortgage_foreclosures.csv` should be saved to `new-america-housing-loss-public/cli/work/mortgage_foreclosures`
+    - `tax_lien_foreclosures.csv` should be saved to `new-america-housing-loss-public/cli/work/tax_lien_foreclosures` 
+
+Then, run FEAT ...
+
+1. Open a terminal and cd into the directory `new-america-housing-loss-public/cli/`
+2. Activate your environment: `conda activate housing_loss_env`
+3. Run the FEAT with your data:
+    1. For Mac/Linux, run `python load_data.py ./work`
+    2. For Windows, run `py load_data.py ./work`
+    
+The output will be available one level up from your data directory in a folder called `output_data`
+
+- The `analysis_plots` directory contains time series and correlation analysis of your content
+- The `data_summaries` directory contains a summary of evictions/foreclosures by geocode (enriched with American Community Survey (ACS) data)
+- The `full_datasets` directory contains all eviction/foreclosure geocoded records
+- The `mapping_data` directory contains a geopackage (.gpkg) file that can be examined using QGIS
+

--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ Get the FEAT code ...
 2. Click `Code` and `Download Zip` to download the code
 3. Unzip the zip file in the directory of your choice
 
-Then setup the FEAT environment
+Then setup the FEAT environment ...
 
-1Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) by selecting the installer that fits your OS version. Once it is installed you may have to restart your terminal (closing your terminal and opening again)
-2Build your environment:
+1. Install [miniconda](https://docs.conda.io/en/latest/miniconda.html) by selecting the installer that fits your OS version. Once it is installed you may have to restart your terminal (closing your terminal and opening again)
+2. Build your environment:
    - On Mac/Linux: 
-     - Open a terminal and change directory to be where you unzipped the FEAT code `new-america-housing-loss-public`
-     - `conda env create -f environment.yml` 
+     - Open a terminal and change directory to be where you unzipped the FEAT code, `new-america-housing-loss-public`
+     - Run command: `conda env create -f environment.yml` 
    - On Windows: 
-     - In the search box bottom right, search for 'Anaconda prompt' and start it
-     - Change directory to be where you unzipped the FEAT code `new-america-housing-loss-public`
-       - `conda env create -f environment_win.yml`
+     - Run program 'Anaconda prompt' 
+     - In the prompt window, change directory to be where you unzipped the FEAT code, `new-america-housing-loss-public`
+     - RUn command: `conda env create -f environment_win.yml`
 
 # Running FEAT
 
@@ -35,15 +35,20 @@ First, create your input data ...
     - `mortgage_foreclosures.csv` should be saved to `new-america-housing-loss-public/cli/work/mortgage_foreclosures`
     - `tax_lien_foreclosures.csv` should be saved to `new-america-housing-loss-public/cli/work/tax_lien_foreclosures` 
 
+TODO: *I think it would be better to provide sample files already in the work folder, then direct the use to edit extend those, referring to the data documentation sheet*
+
 Then, run FEAT ...
 
-1. Open a terminal and cd into the directory `new-america-housing-loss-public/cli/`
-2. Activate your environment: `conda activate housing_loss_env`
-3. Run the FEAT with your data:
-    1. For Mac/Linux, run `python load_data.py ./work`
-    2. For Windows, run `py load_data.py ./work`
+1. Open a terminal for running FEAT
+   - On Mac/Linux start the Terminal application
+   - On Windows start the 'Anaconda prompt' application
+2. Change directory to sub-directory `cli` of where you installed FEAT
+   - `cd <path to FEAT>/new-america-housing-loss-public/cli`
+3. Run FEAT
+   - On Mac/Linux run command: `python load_data.py ./work`
+   - On Windows run command: `py load_data.py ./work`
     
-The output will be available one level up from your data directory in a folder called `output_data`
+The output will be available in a folder called `output_data`
 
 - The `analysis_plots` directory contains time series and correlation analysis of your content
 - The `data_summaries` directory contains a summary of evictions/foreclosures by geocode (enriched with American Community Survey (ACS) data)

--- a/cli/analysis/acs_data.py
+++ b/cli/analysis/acs_data.py
@@ -3,7 +3,10 @@ import datetime
 import os
 import typing as T
 
-import censusdata
+from census import Census
+from us import states
+import sys
+
 import pandas as pd
 
 # line below suppresses annoying SettingWithCopyWarning
@@ -16,80 +19,21 @@ sig_results = {}
 all_results = {}
 
 
-def load_census_data(census_raw_data: pd.DataFrame) -> pd.DataFrame:
+def load_census_data(census_raw_data: pd.DataFrame, census_cols: dict) -> pd.DataFrame:
     """Load the ACS data and generate relevant columns.
 
     Parameters
     ----------
     census_raw_data : pandas df
         Pandas df of raw ACS data
+    vars: dictionary
+        Dictionary of column mappings from census id to human friendly
 
     Returns
     -------
     census_df : pandas df
         Dataframe containing renamed ACS data
     """
-
-    census_cols = {
-        "DP03_0051E": "total-households",
-        "DP04_0047E": "total-renter-occupied-households",
-        "DP04_0046E": "total-owner-occupied-households",
-        "DP03_0062E": "median-household-income",
-        "DP05_0037PE": "pct-white",
-        "DP05_0038PE": "pct-af-am",
-        "DP05_0039PE": "pct-am-in",
-        "DP05_0044PE": "pct-asian",
-        "DP05_0052PE": "pct-nh-pi",
-        "DP05_0057PE": "pct-other-race",
-        "DP05_0058PE": "pct-multiple-race",
-        "DP05_0071PE": "pct-hispanic",
-        "DP03_0119PE": "pct-below-poverty-level",
-        "DP03_0099E": "without-health-insurance",
-        "DP03_0096E": "with-health-insurance",
-        "DP05_0001E": "pop-total",
-        "DP03_0002PE": "pct-pop-in-labor-force",
-        "DP02_0003PE": "pct-households-married-with-own-children",
-        "DP02_0007PE": "pct-male-single-parent-household",
-        "DP02_0011PE": "pct-female-single-parent-household",
-        "DP02_0009PE": "pct-male-older-adult-living-alone",
-        "DP02_0013PE": "pct-female-older-adult-living-alone",
-        "DP02_0014PE": "pct-households-with-children",
-        "DP02_0015PE": "pct-households-with-elderly",
-        "DP02_0053PE": "pct-enrolled-in-school",
-        "DP02_0059E": "education-attained",
-        "DP02_0060E": "level-of-education-less-than-9th",
-        "DP02_0113PE": "pct-non-english-spoken-in-home",
-        "DP02_0114PE": "pct-english-fluency-not-great",
-        "DP02_0152PE": "pct-own-computer",
-        "DP02_0153PE": "pct-broadband-internet",
-        "DP03_0009PE": "unemployment-rate",
-        "DP03_0011PE": "pct-women-in-labor-force",
-        "DP03_0025E": "mean-commute-time",
-        "DP03_0028PE": "pct-service-occupations",
-        "DP03_0021PE": "pct-public-transport-to-work",
-        "DP03_0074PE": "pct-with-snap-benefits",
-        "DP03_0088E": "per-capita-income",
-        "DP03_0093E": "median-income-male-worker",
-        "DP03_0094E": "median-income-female-worker",
-        "DP03_0022PE": "pct-walk-to-work",
-        "DP04_0003PE": "pct-vacant-properties",
-        "DP04_0058PE": "pct-no-vehicles-available",
-        "DP04_0073PE": "pct-incomplete-plumbing",
-        "DP04_0077PE": "pct-one-or-less-occupants-per-room",
-        "DP04_0014PE": "pct-mobile-homes",
-        "DP05_0018E": "median-population-age",
-        "DP02_0069PE": "pct-veterans",
-        "DP02_0094PE": "pct-foreign-born",
-        "DP02_0096PE": "pct-not-us-citizen",
-        "DP02_0072PE": "pct-disability",
-        "B19083_001E": "gini-index",
-        "B25035_001E": "median-year-structure-built",
-        "B25064_001E": "median-gross-rent",
-        "B25077_001E": "median-property-value",
-        "S2506_C01_039E": "median-monthly-housing-cost",
-        "S2506_C01_001E": "total-owner-occupied-households-mortgage",
-    }
-
     census_df = census_raw_data.rename(columns=census_cols)
 
     # some derived ACS quantities are below
@@ -120,6 +64,7 @@ def load_census_data(census_raw_data: pd.DataFrame) -> pd.DataFrame:
         * 100
     )
 
+    census_df["median-year-structure-built"] = pd.to_numeric(census_df["median-year-structure-built"])
     census_df["median-house-age"] = (
         datetime.datetime.now().year - census_df["median-year-structure-built"]
     )
@@ -140,304 +85,104 @@ def load_census_data(census_raw_data: pd.DataFrame) -> pd.DataFrame:
         axis=1,
     )
 
-
-def censusgeo2fips(cg: censusdata.censusgeo) -> str:
-    """Helper function to convert a CensusData geography object into a FIPS code string.
-
-    Parameters
-    ----------
-    cg : censusdata.censusgeo.censusgeo
-        A Census Geography object from the CensusData library.
-
-    Returns
-    -------
-    str
-        The FIPS code as a string
-    """
-    param_dict = {r: v for (r, v) in cg.params()}
-    return f"{param_dict['state']}{param_dict['county']}{param_dict.get('tract', '')}"
-
-
-def fetch_metadata(
-    source: str, year: int, tablenames: T.List, variable_subset: T.List = None
-) -> T.Dict:
-    """Function to get metadata for the variables in a list of tables.
-    Can be optionally filtered to a subset of variables in these tables.
-
-    Parameters
-    ----------
-    source : str
-        The source for the tables in the CensusData package, e.g. "acs5"
-    year : int
-        The year for the source, e.g. 2016
-    tablenames : list
-        A list of tablenames (as strings) to get the variables from.
-    variable_subset : list, optional
-        A subset of variables to restrict the results to.
-
-    Returns
-    -------
-    dict
-        A dictionary of {variable: {metadata_fields}}
-    """
-    variables_dict = {}
-    for t in tablenames:
-        dt = censusdata.censustable(source, year, t)
-        for v in dt.keys():
-            if variable_subset == None or v in variable_subset:
-                variables_dict[v] = dt[v]
-    return variables_dict
-
-
-def fetch_data(
-    source: str,
-    year: int,
-    geo: censusdata.censusgeo,
-    variables_dict: T.Dict,
-    table_type: str,
-    api_key: str,
-) -> pd.DataFrame:
-    """Fetches data from Census Bureau API on a list of variables,
-    and returns a Pandas DataFrame.
-
-    Parameters
-    ----------
-    source : str
-        The source for the tables in the CensusData package, e.g. "acs5"
-    year : int
-        The year for the source, e.g. 2016
-    geo : CensusData geography object
-        Geography level to get data at.
-    variables_dict : dict
-        Dictionary of variables to request from API.
-    table_type : str
-        CensusData name for table containing variables, e.g. 'detail'
-    api_key : str
-        API key for the Census API
-
-    Returns
-    -------
-    Pandas DataFrame
-        Variables as columns, geography as rows
-    """
-    return censusdata.download(
-        source,
-        year,
-        geo,
-        [v for v in variables_dict.keys()],
-        tabletype=table_type,
-        key=api_key,
-    )
-
-
-def get_region_geo(state_id: str, county_id: str) -> censusdata.censusgeo:
-    """Creates the appropriate Census Geography object for each FPR study region.
-
-    Parameters
-    ----------
-    region : string
-        Region/county/city to study
-
-    Returns
-    -------
-    geo : censusgeo object
-        geography object to pass for further ACS data fetching
-
-    """
-    geo = censusdata.censusgeo(
-        [('state', state_id), ('county', county_id), ('tract', '*')]
-    )
-
-    return geo
-
-
-def get_data_for_region(
-    state_id: str,
-    county_id: str,
-    source: str,
-    year: int,
-    dataprofile_tables: T.List = None,
-    subject_tables: T.List = None,
-    detail_tables: T.List = None,
-    dataprofile_filter: T.List = [],
-) -> T.Tuple:
-    """Creates data and data dictionary from Census API for a region.
-
-    Parameters:
-    -----------
-    region : str
-        An FPR study region, e.g. "national" or "forsyth"
-    source : str
-        The Census source survey, e.g. "acs5"
-    year : int
-        The year for the Census source product, e.g. 2016
-    dataprofile_tables : list, optional
-        A list of Data Profile tables to fetch from the API, e.g. ["DP02"]
-    subject_tables : list, optional
-        A list of Subject tables to fetch from the API, e.g. ["S1701_C01"]
-    detail_tables : list, optional
-        A list of Detail tables to fetch from the API, e.g. ["B25003"]
-    dataprofile_filter : list, optional
-        A list of Data Profile variables to filter from the fetched tables, e.g. ["DP02_0003E"]
-
-    Returns
-    -------
-    tuple
-        (DataFrame, dict) -> the data and data dictionary respectively
-    """
-    geo = get_region_geo(state_id, county_id)
-    data_dictionary = {}
-    retrieved_data = []
-
-    if dataprofile_tables != None:
-        dataprofile_variables = fetch_metadata(
-            source, year, dataprofile_tables, variable_subset=dataprofile_filter
-        )
-        retrieved_data.append(
-            fetch_data(
-                source, year, geo, dataprofile_variables, "profile", CENSUS_API_KEY
-            )
-        )
-        data_dictionary.update(dataprofile_variables)
-
-    if subject_tables != None:
-        subject_variables = fetch_metadata(source, year, subject_tables)
-        retrieved_data.append(
-            fetch_data(source, year, geo, subject_variables, "subject", CENSUS_API_KEY)
-        )
-        data_dictionary.update(subject_variables)
-
-    if detail_tables != None:
-        detail_variables = fetch_metadata(source, year, detail_tables)
-        retrieved_data.append(
-            fetch_data(source, year, geo, detail_variables, "detail", CENSUS_API_KEY)
-        )
-        data_dictionary.update(detail_variables)
-
-    # Combine data into a single DataFrame
-    all_data = pd.concat(retrieved_data, axis=1).reset_index()
-    all_data["GEOID"] = all_data["index"].apply(censusgeo2fips)
-
-    return all_data, data_dictionary
-
-
 def get_acs_data(
-    state_fips: str, county_fips: str, year: int = 2019
+    state_fips: str, county_fips: str, year: int = 2019 # The max here is determined by 'censusdata' package
 ) -> T.Union[T.Tuple[pd.DataFrame, T.Dict], T.Tuple[None, None]]:
     """Main function to get ACS data from the census API."""
     if state_fips is None or county_fips is None:
         return (None, None)
 
-    dataprofile_tables = ["DP02", "DP03", "DP04", "DP05"]
+    vars = {
+        "dataprofile": {
+            "DP03_0051E": "total-households",
+            "DP04_0047E": "total-renter-occupied-households",
+            "DP04_0046E": "total-owner-occupied-households",
+            "DP03_0062E": "median-household-income",
+            "DP05_0037PE": "pct-white",
+            "DP05_0038PE": "pct-af-am",
+            "DP05_0039PE": "pct-am-in",
+            "DP05_0044PE": "pct-asian",
+            "DP05_0052PE": "pct-nh-pi",
+            "DP05_0057PE": "pct-other-race",
+            "DP05_0058PE": "pct-multiple-race",
+            "DP05_0071PE": "pct-hispanic",
+            "DP03_0119PE": "pct-below-poverty-level",
+            "DP03_0099E": "without-health-insurance",
+            "DP03_0096E": "with-health-insurance",
+            "DP05_0001E": "pop-total",
+            "DP03_0002PE": "pct-pop-in-labor-force",
+            "DP02_0003PE": "pct-households-married-with-own-children",
+            "DP02_0007PE": "pct-male-single-parent-household",
+            "DP02_0011PE": "pct-female-single-parent-household",
+            "DP02_0009PE": "pct-male-older-adult-living-alone",
+            "DP02_0013PE": "pct-female-older-adult-living-alone",
+            "DP02_0014PE": "pct-households-with-children",
+            "DP02_0015PE": "pct-households-with-elderly",
+            "DP02_0053PE": "pct-enrolled-in-school",
+            "DP02_0059E": "education-attained",
+            "DP02_0060E": "level-of-education-less-than-9th",
+            "DP02_0113PE": "pct-non-english-spoken-in-home",
+            "DP02_0114PE": "pct-english-fluency-not-great",
+            "DP02_0152PE": "pct-own-computer",
+            "DP02_0153PE": "pct-broadband-internet",
+            "DP03_0009PE": "unemployment-rate",
+            "DP03_0011PE": "pct-women-in-labor-force",
+            "DP03_0025E": "mean-commute-time",
+            "DP03_0028PE": "pct-service-occupations",
+            "DP03_0021PE": "pct-public-transport-to-work",
+            "DP03_0074PE": "pct-with-snap-benefits",
+            "DP03_0088E": "per-capita-income",
+            "DP03_0093E": "median-income-male-worker",
+            "DP03_0094E": "median-income-female-worker",
+            "DP03_0022PE": "pct-walk-to-work",
+            "DP04_0003PE": "pct-vacant-properties",
+            "DP04_0058PE": "pct-no-vehicles-available",
+            "DP04_0073PE": "pct-incomplete-plumbing",
+            "DP04_0077PE": "pct-one-or-less-occupants-per-room",
+            "DP04_0014PE": "pct-mobile-homes",
+            "DP05_0018E": "median-population-age",
+            "DP02_0069PE": "pct-veterans",
+            "DP02_0094PE": "pct-foreign-born",
+            "DP02_0096PE": "pct-not-us-citizen",
+            "DP02_0072PE": "pct-disability"
+        },
+        "subject": {
+            "S2506_C01_039E": "median-monthly-housing-cost",
+            "S2506_C01_001E": "total-owner-occupied-households-mortgage",
+        },
+        "detail":{
+            "B19083_001E": "gini-index",
+            "B25035_001E": "median-year-structure-built",
+            "B25064_001E": "median-gross-rent",
+            "B25077_001E": "median-property-value"
+        }
+    }
 
-    fpr_variables_wishlist = [
-        "DP02_0003PE",
-        "DP02_0007PE",
-        "DP02_0009PE",
-        "DP02_0011PE",
-        "DP02_0013PE",
-        "DP02_0014PE",
-        "DP02_0015PE",
-        "DP02_0033E",
-        "DP02_0053PE",
-        "DP02_0059E",
-        "DP02_0060E",
-        "DP02_0069PE",
-        "DP02_0072PE",
-        "DP02_0094PE",
-        "DP02_0096PE",
-        "DP02_0113PE",
-        "DP02_0114PE",
-        "DP02_0152PE",
-        "DP02_0153PE",
-        "DP03_0001E",
-        "DP03_0002PE",
-        "DP03_0009PE",
-        "DP03_0011PE",
-        "DP03_0021PE",
-        "DP03_0022PE",
-        "DP03_0025E",
-        "DP03_0028PE",
-        "DP03_0051E",
-        "DP03_0054E",
-        "DP03_0062E",
-        "DP03_0074PE",
-        "DP03_0088E",
-        "DP03_0093E",
-        "DP03_0094E",
-        "DP03_0096E",
-        "DP03_0099E",
-        "DP03_0119PE",
-        "DP04_0003PE",
-        "DP04_0014PE",
-        "DP04_0046E",
-        "DP04_0047E",
-        "DP04_0058PE",
-        "DP04_0073PE",
-        "DP04_0077PE",  # look to ~0140s for rent
-        "DP05_0001E",
-        "DP05_0018E",
-        "DP05_0033E",
-        "DP05_0037PE",
-        "DP05_0038PE",
-        "DP05_0039PE",
-        "DP05_0044PE",
-        "DP05_0052PE",
-        "DP05_0057PE",
-        "DP05_0058PE",
-        "DP05_0071PE",
-    ]
-    subject_tables = [
-        # Poverty status in past 12 months
-        "S1701_C01",
-        # Demographic characteristics for occupied housing units, for all + owner-occupied + renter-occupied
-        "S2502_C01",
-        "S2502_C02",
-        "S2502_C03",
-        # Physical housing characteristics for occupied housing units, for all + owner-occupied + renter-occupied
-        "S2504_C01",
-        "S2504_C02",
-        "S2504_C03",
-        # Physical housing characteristics, mortgaged houses only
-        "S2506_C01",
-    ]
-    # Additional detail tables relevant to housing
-    detail_tables = [
-        "B01003",  #
-        "B19083",  # Income inequality?
-        "B25003",  # Tenure
-        "B25003B",
-        "B25004",  # Vacancy status
-        "B25035",  # Median year structure built
-        "B25056",  # Contract rent
-        "B25057",  # Lower quartile contract rent
-        "B25058",  # Median contract rent
-        "B25059",  # Upper quartile contract rent
-        "B25061",  # Rent asked
-        "B25063",  # Gross rent
-        "B25064",  # Median gross rent
-        "B25070",  # Gross rent as a percentage of household income in past 12 months
-        "B25074",  # Household income by gross rent as a percentage of household income in past 12 months
-        "B25075",  # Value
-        "B25076",  # Lower value quartile
-        "B25077",  # Median value quartile
-        "B25078",  # Upper value quartile,
-        "B25087",  # Mortgage status and selected monthly owner costs by mortgage status
-        "B25088",  # Median selected monthly owner costs by mortgage status
-        "B25092",  # Median selected monthly owner costs as a % of household income
-    ]
+    c = Census(CENSUS_API_KEY, year=year)
+    dfs = []
 
-    data, data_dict = get_data_for_region(
-        state_fips,
-        county_fips,
-        "acs5",
-        year,
-        dataprofile_tables=dataprofile_tables,
-        subject_tables=subject_tables,
-        detail_tables=detail_tables,
-        dataprofile_filter=fpr_variables_wishlist,
-    )
+    var_list = list(vars['dataprofile'].keys())
+    df = pd.DataFrame(c.acs5dp.state_county_tract((var_list), state_fips, county_fips, Census.ALL))
+    df.drop(['state', 'county', 'tract'], axis=1, inplace=True)
+    dfs.append(df)
 
-    census_df = load_census_data(data)
+    var_list = list(vars['subject'].keys())
+    df = pd.DataFrame(c.acs5st.state_county_tract((var_list), state_fips, county_fips, Census.ALL))
+    df.drop(['state', 'county', 'tract'], axis=1, inplace=True)
+    dfs.append(df)
+
+    var_list = list(vars['detail'].keys())
+    df = pd.DataFrame(c.acs5.state_county_tract((var_list), state_fips, county_fips, Census.ALL))
+    dfs.append(df)
+
+    data = pd.concat( dfs, axis=1).reset_index()
+    data_dict=pd.DataFrame()
+
+    census_cols = vars['dataprofile']
+    census_cols.update(vars['subject'])
+    census_cols.update(vars['detail'])
+
+    census_df = load_census_data(data, census_cols)
+    census_df["GEOID"] = census_df['state'].astype(str) + census_df['county'].astype(str) + census_df['tract'].astype(str)
 
     return census_df, data_dict

--- a/cli/collection/address_validation.py
+++ b/cli/collection/address_validation.py
@@ -14,7 +14,7 @@ def verify_input_directory(input_path: str) -> T.List:
     directory_contents = [x for x in Path(input_path).iterdir()]
     sub_directories = set(
         [
-            str(f).replace(input_path, '').lower()
+            str(f).split('/')[-1].lower()
             for f in directory_contents
             if f.is_dir()
         ]
@@ -27,7 +27,7 @@ def verify_input_directory(input_path: str) -> T.List:
         print('\u2326  No sub-directories present in input directory')
         return None
     if len(sub_directories.intersection(REQUIRED_SUB_DIRECTORIES)) == 0:
-        print('\u2326  Required sub-directories missing from input directory')
+        print(f'\u2326  Required sub-directories - {REQUIRED_SUB_DIRECTORIES} - missing from input directory')
         return None
     print('\u2713  Required sub-directories found in input directory!')
     return [Path(input_path) / sd for sd in sub_directories]

--- a/cli/const.py
+++ b/cli/const.py
@@ -13,12 +13,20 @@ REQUIRED_ADDRESS_COLUMNS = ['street_address_1', 'city', 'state', 'zip_code']
 MIN_YEAR = 2016
 MAX_YEAR = 2999
 
+# The year used to get ACS data
+ACS_YEAR = 2020
+
 GEOCODE_URL = 'https://geocoding.geo.census.gov/geocoder/geographies/addressbatch'
 GEOCODE_PAYLOAD = {
     'benchmark': 'Public_AR_Current',
     'vintage': 'Current_Current',
+    #'benchmark':'Public_AR_Census2020',
+    #'vintage':'Public_AR_Census2020',
     'response': 'json',
 }
+
+#https://geocoding.geo.census.gov/geocoder/vintages?benchmark=Public_AR_Current
+
 GEOCODE_RESPONSE_HEADER = [
     'id',
     'geocoded_address',

--- a/cli/load_data.py
+++ b/cli/load_data.py
@@ -34,6 +34,7 @@ from collection.tigerweb_api import (
 )
 from const import (
     ACS_DATA_DICT_FILENAME,
+    ACS_YEAR,
     GEOCODED_EVICTIONS_FILENAME,
     GEOCODED_FORECLOSURES_FILENAME,
     GEOCODED_TAX_LIENS_FILENAME,
@@ -362,7 +363,7 @@ def main(input_path: str) -> None:
 
     # GRAB ACS DATA; used in housing loss summary and demographic correlation search
     print("\nPreparing to get ACS data...")
-    acs_df, acs_data_dict = get_acs_data(state_fips, county_fips)
+    acs_df, acs_data_dict = get_acs_data(state_fips, county_fips, ACS_YEAR)
     if acs_df is None:
         print(
             '\u2326  Insufficient geography information to retrieve ACS Data!',

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+name: housing_loss_env
+dependencies:
+  - pip
+  - python=3.8.10
+  - pip:
+    - -r requirements.txt

--- a/environment_win.yml
+++ b/environment_win.yml
@@ -1,0 +1,8 @@
+name: housing_loss_env
+dependencies:
+  - pip
+  - python=3.8.10
+  - pip:
+    - whl/GDAL-3.3.3-cp38-cp38-win_amd64.whl
+    - whl/Fiona-1.8.20-cp38-cp38-win_amd64.whl
+    - -r requirements.txt


### PR DESCRIPTION
Users reported an issue where rows were being dropped, identified by comparing totals in summary csv file and row count in input files. Though some rows were dropped due to address parsing, most were dropped because the data for ACS was generated using year=2019, but for the gecoding of evictions it was 2020. Census tracts changed resulting is data being dropped. Unfortunately, it wasn't possible to simply increment ACS year as the python module used to provide the data `censusdata` is no longer being actively developed, so this fix includes a migration to a supported ACS python module.

